### PR TITLE
gates refactor

### DIFF
--- a/qfunc.cabal
+++ b/qfunc.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 882d23a73f044212c3f5b67da68d8d1bd192bc564a864b9d06969ee3ef8b4d54
+-- hash: 4bb7e9c48cf8e6c886b05c8cf166f53c6ebb9eebfc6471107e8df04b2d5afaa5
 
 name:           qfunc
 version:        0.1.0.0
@@ -40,8 +40,7 @@ library
       QM
       CoinFlip
       Deutsch
-      DeutschJosza
-      Logic
+      DeutschJozsa
       Teleport
   other-modules:
       Paths_qfunc

--- a/src/Gates.hs
+++ b/src/Gates.hs
@@ -21,7 +21,6 @@ module Gates (
     , tdagger
     , fredkin
     , toffoli
-    , hmat
 ) where
 
 import Internal.Gates

--- a/src/Gates.hs
+++ b/src/Gates.hs
@@ -21,9 +21,20 @@ module Gates (
     , tdagger
     , fredkin
     , toffoli
+    , hmat
 ) where
 
-import Internal.Gates ( i, applyGate, runGate, controlMatrix, ccontrolMatrix )
+import Internal.Gates
+    ( ccontrolMatrix,
+      controlMatrix,
+      runGate,
+      applyGate,
+      hmat,
+      pXmat,
+      pYmat,
+      pZmat,
+      phasemat,
+      idmat ) 
 import QM ( QM, QState(QState), QBit(..), getState, put, get)
 import Numeric.LinearAlgebra
     ( Complex(..), (#>), (><), ident, kronecker, Matrix, Linear(scale), C, ident, tr )
@@ -42,8 +53,7 @@ import Numeric.LinearAlgebra
 cnot :: (QBit, QBit) -> QM (QBit, QBit)
 cnot (c, t) = do
   (_, size) <- getState
-  let matrixX = (2 >< 2) [ 0, 1, 1, 0 ]
-  let g = controlMatrix size c t matrixX
+  let g = controlMatrix size c t pXmat 
   applyGate g
   return (c,t)
 
@@ -71,9 +81,8 @@ cnot (c, t) = do
 --  ![toffoli](images/toffoli.PNG)
 toffoli :: (QBit, QBit, QBit) -> QM (QBit, QBit, QBit)
 toffoli (c1,c2,t) = do
-  (_, size) <- getState 
-  let matrixX = (2 >< 2) [ 0, 1, 1, 0 ]
-  let g = ccontrolMatrix size c1 c2 t matrixX
+  (_, size) <- getState
+  let g = ccontrolMatrix size c1 c2 t pXmat 
   applyGate g
   return (c1,c2,t)
 
@@ -86,9 +95,7 @@ toffoli (c1,c2,t) = do
 --
 -- ![pauliX](images/x.PNG)
 pauliX :: QBit -> QM QBit
-pauliX = runGate $ (2 >< 2)
-  [ 0 , 1
-  , 1 , 0 ]
+pauliX = runGate pXmat
 
 -- | Pauli-Y gate
 --
@@ -99,9 +106,7 @@ pauliX = runGate $ (2 >< 2)
 --
 -- ![pauliY](images/y.PNG)
 pauliY :: QBit -> QM QBit
-pauliY = runGate $ (2 >< 2)
-  [ 0 , -i
-  , i ,  0 ]
+pauliY = runGate pYmat 
 
 -- | Pauli-Z gate
 --
@@ -112,9 +117,7 @@ pauliY = runGate $ (2 >< 2)
 --
 -- ![pauliZ](images/z.PNG)
 pauliZ :: QBit -> QM QBit
-pauliZ = runGate $ (2 >< 2)
-  [ 1 ,  0
-  , 0 , -1 ]
+pauliZ = runGate pZmat 
 
 -- | Hadamard gate
 -- 
@@ -125,9 +128,7 @@ pauliZ = runGate $ (2 >< 2)
 --
 -- ![hadamard](images/h.PNG)
 hadamard :: QBit -> QM QBit
-hadamard = runGate $ scale (sqrt 0.5) $ (2 >< 2)
-    [ 1 ,  1
-    , 1 , -1 ]
+hadamard = runGate hmat
 
 -- | Phase gate
 --
@@ -138,9 +139,7 @@ hadamard = runGate $ scale (sqrt 0.5) $ (2 >< 2)
 --
 -- ![phase](images/s.PNG)
 phase :: QBit -> QM QBit
-phase = runGate $ (2 >< 2)
-  [ 1 , 0
-  , 0 , i ]
+phase = runGate $ phasemat pi/2
 
 -- | Pi/8 gate (T gate)
 --
@@ -151,17 +150,11 @@ phase = runGate $ (2 >< 2)
 --
 -- ![pi8](images/t.PNG)
 phasePi8 :: QBit -> QM QBit
-phasePi8 = runGate $ (2 >< 2)
-  [ 1 , 0
-  , 0 , p ]
-  where p = exp (i * pi / 4)
+phasePi8 = runGate $ phasemat pi/4
 
 -- | Hermetian adjoint of T gate (`phasePi8`)
 tdagger :: QBit -> QM QBit
-tdagger = runGate $ (2 >< 2)
-  [ 1 , 0
-  , 0 , p ]
-  where p = exp (-i * pi / 4)
+tdagger = runGate $ phasemat (-pi/4)
 
 -- | Identity gate
 --
@@ -171,9 +164,7 @@ tdagger = runGate $ (2 >< 2)
 -- \end{bmatrix} \]
 --
 identity :: QBit -> QM QBit
-identity = runGate $ (2 >< 2)
-  [ 1 , 0
-  , 0 , 1 ]
+identity = runGate idmat
 
 -- | SWAP gate
 -- 

--- a/src/Internal/Gates.hs
+++ b/src/Internal/Gates.hs
@@ -109,7 +109,7 @@ cmat = (4 >< 4)
 phasemat :: Double -> Matrix C
 phasemat r = (2 >< 2)
   [ 1, 0
-  , 0, p]
+  , 0, p ]
   where p = exp (i*(r :+ 0))
 
 -- | PauliX matrix

--- a/src/Internal/Gates.hs
+++ b/src/Internal/Gates.hs
@@ -8,12 +8,26 @@ Stability   : experimental
 
 Internal matrix operations
 -}
+{-# LANGUAGE FlexibleInstances #-}
 module Internal.Gates where
 
-import QM ( QM, QState(QState), QBit(..), put, get, getState )
+import QM ( QM, QState(QState), QBit(..), put, get, getState ) 
 import Numeric.LinearAlgebra
-    ( (#>), (><), ident, kronecker, Complex(..), Matrix, C, toInt, asColumn, asRow, mTm, Linear (scale) )
-
+    ( (#>),
+      (><),
+      dispcf,
+      ident,
+      kronecker,
+      Complex(..),
+      Matrix,
+      Linear(scale),
+      C )
+   
+import Numeric.LinearAlgebra.Data
+    ( (><), dispcf, ident, Complex(..), Matrix, C )
+instance {-# OVERLAPS#-} Show (Matrix C) where
+  show mx = dispcf 3 mx
+  
 -- | The imaginary unit
 i :: Complex Double
 i = 0 :+ 1

--- a/src/Internal/Gates.hs
+++ b/src/Internal/Gates.hs
@@ -11,8 +11,17 @@ Internal matrix operations
 {-# LANGUAGE FlexibleInstances #-}
 module Internal.Gates where
 
-import QM
+import QM ( getState, get, put, QM, QState(QState), QBit(..) )
 import Numeric.LinearAlgebra
+    ( Complex(..),
+      C,
+      (#>),
+      (><),
+      dispcf,
+      ident,
+      kronecker,
+      Matrix,
+      Linear(scale) )
 instance {-# OVERLAPS#-} Show (Matrix C) where
   show mx = dispcf 3 mx
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,52 +9,80 @@ import QM
 import Numeric.LinearAlgebra as LA
 import Internal.Gates (i)
 
-
+-- | Maximum allowed length of QState
 maxAllowedN :: Int
 maxAllowedN = 10
+
+-- | The margin allowed for equality checking
+eqMargin :: Double
+eqMargin = 0.000001
+
+-- | The error message returned when maxAllowedN is exceeded
+maxExceededErrorMsg :: String
+maxExceededErrorMsg = "your computer almost just died. either you forgot to input a value, or you want to raise the value for allowed inputs"
 
 -- | Sample tests
 main :: IO ()
 main = do
   quickCheck $ prop_unitary hmat
-  quickCheck   prop_hadamard
-  quickCheck $ prop_norm 8 
-
-
+  quickCheck $ prop_hadamard 8
+  quickCheck $ prop_norm 8
 
 -- | Checks that the QState of arbitrary size after a hadamard gate is applied keeps a good norm and
 -- that the QState vector only contains two amplitudes at 1/sqrt(2).
-
--- Especially this function may kill your computer if it's let to run without max bounds.
+-- This function in particular may kill your computer if it's let to run without max bounds.
 prop_hadamard :: Int -> Property
 prop_hadamard n
-  | n > maxAllowedN = errorWithoutStackTrace "your computer almost just died. either you forgot to input a value, or you want to raise the value for allowed inputs"
+  | n > maxAllowedN = errorWithoutStackTrace maxExceededErrorMsg
   | otherwise = monadicIO $ do
     m <- pick $ choose (1,n)
     TM.forAllM (genBits n) $ assertive m
-      where
-            assertive :: Int -> [Bit] -> PropertyM IO ()
+      where assertive :: Int -> [Bit] -> PropertyM IO ()
             assertive m bs = do
               qs@(QState s) <- qrun $ mapM new bs >>= \x -> hadamard (x !! div (length bs-1) m) >> get
-              assert $ goodNorm qs && length (filter (eqAlmost (1/sqrt 2)) (toList s)) == 2
-
-
+              assert $ goodNorm qs && length (filter ((1/sqrt 2) ~=) (toList s)) == 2
 
 -- | Checks that the norm of generated QStates, of 1 < lengths < n , is one
 prop_norm :: Int -> Property
 prop_norm n
-  | n > maxAllowedN = errorWithoutStackTrace "your computer almost just died. either you forgot to input a value, or you want to raise the value for allowed inputs"
+  | n > maxAllowedN = errorWithoutStackTrace maxExceededErrorMsg
   | otherwise = monadicIO $
   TM.forAllM (genBits n) assertive
-  where
-        assertive :: [Bit] -> PropertyM IO ()
+  where assertive :: [Bit] -> PropertyM IO ()
         assertive bs = do
           qs <- qrun $ mapM_ new bs >> get
           assert $ goodNorm qs
 
+-- | Checks that the given matrix is unitary
+prop_unitary :: Matrix C -> Property
+prop_unitary mx = foldl (.&&.) isSquare [ isConjugate, innerHolds mx , normal ]
+  where isSquare    = property $ rows mx == cols mx
+        isConjugate = property $ (#=) (mx LA.<> conj mx) (ident (rows mx))
+        normal      = property $ (#=) (conj mx LA.<> mx) (mx LA.<> conj mx)
+        detIsOne    = property $ (~=) (abs (det mx)) 1
+
+-- | Checks that the inner product holds during matrix transformations
+innerHolds :: Matrix C -> Property
+innerHolds mx = forAll genNs test
+  where test bs = (~=) ((#>) mx (randV 0 bs) <.> (#>) mx (randV 1 bs)) (randV 0 bs <.> randV 1 bs)
+        randV n bs = toColumns (ident (rows mx)) !! (bs !! n)
+        genNs = vectorOf 2 (choose (0, rows mx - 1))
+
+-- | Compareas two complex numbers for equality to the 6th decimal
+(~=) :: C -> C -> Bool
+(~=) a b = bm - eqMargin <= am && am <= bm + eqMargin
+  where am = magnitude a
+        bm = magnitude b
+
+-- | Compares two complex matrices for equality, using eqAlmost. 
+(#=) :: Matrix C -> Matrix C -> Bool
+(#=) mx nx = all (==True) $ zipWith (~=) list1 list2
+  where list1 = (concat . toLists) mx
+        list2 = (concat . toLists) nx
+
 -- | Checks that the norm of the given QState is 1
 goodNorm :: QState -> Bool
-goodNorm (QState s) = eqAlmost (norm_2 s :+ 0) 1
+goodNorm (QState s) = (~=) (norm_2 s :+ 0) 1
 
 -- | Generates a bit string of given length
 genBits :: Int -> Gen [Bit]
@@ -63,34 +91,6 @@ genBits n = vectorOf n (elements [0,1])
 -- | Runs a QM program in PropertyM
 qrun :: QM a -> PropertyM IO a
 qrun = TM.run . QM.run
-
--- | Checks that the given matrix is unitary
-prop_unitary :: Matrix C -> Property
-prop_unitary mx = foldl (.&&.) isSquare [ isConjugate, innerHolds mx , normal ]
-  where isSquare = property $ rows mx == cols mx
-        isConjugate =  property $ eqAlmostMat (mx LA.<> conj mx) (ident (rows mx))
-        normal = property $ eqAlmostMat (conj mx LA.<> mx) (mx LA.<> conj mx)
-        detIsOne = property $ eqAlmost (abs (det mx)) 1
-
--- | Checks that the inner product between matrix transformations holds
-innerHolds :: Matrix C -> Property
-innerHolds mx = forAll genNs test
-  where test bs = eqAlmost ((#>) mx (randV 0 bs) <.> (#>) mx (randV 1 bs)) (randV 0 bs <.> randV 1 bs)
-        randV n bs = toColumns (ident (rows mx)) !! (bs !! n)
-        genNs = vectorOf 2 (choose (0, rows mx - 1))
-
--- | Compareas two complex numbers for equality to the 6th decimal
-eqAlmost :: C -> C -> Bool
-eqAlmost a b = bm-0.000001 <= am && am <= bm+0.000001
-  where am = magnitude a
-        bm = magnitude b
-
--- | Compares two complex matrices for equality, using eqAlmost. 
-eqAlmostMat :: Matrix C -> Matrix C -> Bool
-eqAlmostMat mx nx = all (==True) $ zipWith eqAlmost list1 list2
-  where  list1 = (concat . toLists) mx
-         list2 = (concat . toLists) nx
-
 
 -- | Test matrices for isUnitary
 -- | Hadamard matrix


### PR DESCRIPTION
Include gate matrices in Internal/Gates. These are exported and run in other files. The purpose is to get easier access to gate matrices.